### PR TITLE
ci: Force initial versions of packages to be 0.1.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,8 @@
 {
-  ".": "0.0.1"
+  ".": "0.0.1",
+  "packages/f5-ai/moderator": "0.1.0",
+  "packages/f5-ai/scanner": "0.1.0",
+  "packages/f5-ai/redteam": "0.1.0",
+  "packages/gateway-api-inference-extension/body-based-routing": "0.1.0",
+  "packages/gateway-api-inference-extension/inference-pool": "0.1.0"
 }


### PR DESCRIPTION
These packages are still a work in progress; set initial release version as `0.1.0` for each package.